### PR TITLE
Add manifest file for qubes-builder

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,0 +1,8 @@
+MIRAGE_KERNEL_NAME = qubes_ssh_agent.xen
+SOURCE_BUILD_DEP := ssh-agent-build-dep
+OCAML_VERSION ?= 4.05.0
+
+ssh-agent-build-dep:
+	opam pin -y add angstrom https://github.com/reynir/angstrom.git#no-c-blit
+	opam pin -y add ssh-agent https://github.com/reynir/ocaml-ssh-agent.git
+


### PR DESCRIPTION
Note that builder-mirage qubes-builder plugin hasn't been heavily tested yet, so this file may require some changes if some API level bug is found. But I hope it wouldn't happen ;)

You may want to wait until related pins are no longer needed. Or drop them later.

builder.conf to make use of it:
```
GIT_BASEURL ?= https://github.com
GIT_PREFIX ?= marmarek/qubes-
NO_SIGN ?= 1
VERBOSE ?= 2

DISTS_VM = mirage+mirage-ssh-agent
DIST_DOM0 =
TEMPLATE_LABEL = mirage+mirage-ssh-agent:mirage-ssh-agent

COMPONENTS = \
        mirage-ssh-agent \
        linux-template-builder \
        builder-mirage

BUILDER_PLUGINS = builder-mirage

GIT_URL_mirage_ssh_agent = https://github.com/reynir/qubes-mirage-ssh-agent
```

Note that building MirageOS on Fedora is kind of broken, but template-builder on Debian require at least https://github.com/QubesOS/qubes-linux-template-builder/pull/9