### PR TITLE
remove all mentions of GUI (which is unused and currently breaks the build)

### DIFF
--- a/unikernel.ml
+++ b/unikernel.ml
@@ -53,27 +53,9 @@ let handler ~user command flow : int Lwt.t =
 
 module Main (DB : Qubes.S.DB) = struct
 
-  (* We don't use the GUI, but it's interesting to keep an eye on it.
-     If the other end dies, don't let it take us with it (can happen on log out). *)
-  let watch_gui gui =
-    Lwt.async (fun () ->
-      Lwt.try_bind
-        (fun () ->
-           gui >>= fun gui ->
-           Log.info (fun f -> f "GUI agent connected");
-           Qubes.GUI.listen gui
-        )
-        (fun `Cant_happen -> assert false)
-        (fun ex ->
-          Log.warn (fun f -> f "GUI thread failed: %s" (Printexc.to_string ex));
-          Lwt.return ()
-        )
-    )
-
   let start _qubesdb () =
     Log.info (fun f -> f "Starting...");
     let qrexec = Qubes.RExec.connect ~domid:0 () in
-    Qubes.GUI.connect ~domid:0 () |> watch_gui;
     qrexec >>= fun qrexec ->
     let agent_listener = Qubes.RExec.listen qrexec
         handler in


### PR DESCRIPTION
this is more of a "i dont understand ocaml" class workaround.
works though, and the GUI part is currently unused anyways.
and if anyone wants to add actual gui functionality, bringing it back is trivial.

"fixes" https://github.com/reynir/qubes-mirage-ssh-agent/issues/11